### PR TITLE
chore(dependabot): align cooldown with npm min release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
     rebase-strategy: 'auto'

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.yarnpkg.com/
+min-release-age=7


### PR DESCRIPTION
## Summary
- add a Dependabot cooldown to npm updates
- set the cooldown to 7 days to match .npmrc min-release-age
- keep the existing daily schedule and rebase strategy

## Testing
- not run (config-only change)